### PR TITLE
Add opportunity pass context	

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Clean for webpack
 A webpack plugin to remove/clean your build folder(s) before building
 
-## Usage
+## `new Clean(paths, context)`
+* **Parameters**
+    - **paths**: Array of paths *['dist', 'build']*  
+    - **context**: root path, by default uses path where located *webpack.config.js* 
+
+## Example
 
 ``` javascript
-var Clean = require("clean-webpack-plugin");
+var Clean = require('clean-webpack-plugin');
 module.exports = {
-	plugins: [
-		new Clean(['dist', 'build'])
-	]
+    plugins: [
+    new Clean(['dist', 'build'])
+  ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A webpack plugin to remove/clean your build folder(s) before building
 
 ## `new Clean(paths, context)`
 * **Parameters**
-    - **paths**: Array of paths *['dist', 'build']*  
+    - **paths**: Array of paths *(example: ['dist', 'build'])*  
     - **context**: root path, by default uses path where located *webpack.config.js* 
 
 ## Example

--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@ var rimraf = require('rimraf')
 var path = require('path');
 var join = path.join;
 
-function Plugin(paths) {
+function Plugin(paths, context) {
   // determine webpack root
-  this.context = path.dirname(module.parent.filename);
+  this.context = context || path.dirname(module.parent.filename);
 
   // allows for a single string entry
   if (typeof paths == 'string' || paths instanceof String){


### PR DESCRIPTION
If **webpack** configuration file located not in root folder (like **webpack/webpack.config.js**) it's not possible use plugin. I've added opportunity to set root path.