### PR TITLE
Resolve paths instead of joining

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-var rimraf = require('rimraf')
+var rimraf = require('rimraf');
 var path = require('path');
-var join = path.join;
+var resolve = path.resolve;
 
 function Plugin(paths, context) {
   // determine webpack root
@@ -20,9 +20,9 @@ Plugin.prototype.apply = function(compiler) {
 
   // preform an rm -rf on each path
   self.paths.forEach(function(path){
-    var path = join(self.context, path);
+    path = resolve(self.context, path);
     rimraf.sync(path);
   });
-}
+};
 
 module.exports = Plugin;


### PR DESCRIPTION
Hi there.  I'm trying to use your plugin with an absolute path, but it doesn't work.  I made a small change (replaced `path.join` with `path.resolve`), which allows absolute paths to be used in addition to relative paths.