### PR TITLE
Safer delete

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ function Plugin(paths, context) {
 Plugin.prototype.apply = function(compiler) {
   var self = this;
 
+  // exit if no paths passed in
+  if(self.paths === void 0)
+    return
+
   // preform an rm -rf on each path
   self.paths.forEach(function(path){
     path = resolve(self.context, path);

--- a/index.js
+++ b/index.js
@@ -22,10 +22,18 @@ Plugin.prototype.apply = function(compiler) {
   if(self.paths === void 0)
     return
 
+  var projectDir = path.dirname(module.parent.filename)
+
   // preform an rm -rf on each path
   self.paths.forEach(function(path){
     path = resolve(self.context, path);
-    rimraf.sync(path);
+
+    // disallow deletion of project path and any directories outside of project path.
+    if(path != projectDir && path.indexOf(projectDir) === 0){
+      rimraf.sync(path);
+    } else {
+      console.warn("Clean webpack did not delete path: " + path);
+    }
   });
 };
 


### PR DESCRIPTION
Thanks for creating this plugin, it is useful.

I ran into a problem I had though. This plugin definitely very dangerous... this PR makes it a little less dangerous...

So I passed in

```
// WARNING: DON'T DO THIS AT HOME
var Clean = require('clean-webpack-plugin');
new Clean('');
// DO NOT DO THIS AT HOME.
```
and....... it deleted everything in my current project path. Bye bye, `.git` directory...
gladly it was a beginning of a small project, and the important files I still had tabs open...

but yeh, kinda nuts. I was trying to tell Clean to delete nothing, and I thought passing in an empty string, will cause it to not delete anything..... instead it deleted everything....

This PR prevents this... disallows deleting of the entire project library, also makes sure anything you do delete is a sub-folder of the current project....

```
// Also prevents these dangerous deletions...
// WARNING DO NOT TRY THIS!
Clean(['', '.', '../', '/'])
Clean(['', '.', '../', '/'], '/root/folder')
// WARNING DON'T DO THIS!
```