### PR TITLE
Added support for excluding specific immediate children from cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ module.exports = {
     new CleanWebpackPlugin(['dist', 'build'], {
       root: '/full/project/path',
       verbose: true, 
-      dry: false
+      dry: false,
+      exclude: ['shared.js']
     })
   ]
 }
@@ -44,6 +45,9 @@ An [array] of string paths to clean
   "root": "[location of webpack.config]", // An absolute path for the root.
   "verbose": true, // Write logs to console.
   "dry": false, // Do not delete anything, good for testing.
+  "exclude": ["files", "to", "ignore"] // Instead of removing whole path recursively, 
+                                       // remove all path's content with exclusion of provided immediate children.
+                                       // Good for not removing shared files from build directories.
 }
 ```
 

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -16,7 +16,10 @@ describe('clean-webpack-plugin', function () {
     this.projectRoot = path.resolve(process.cwd(), 'test/project_root');
     this.dirOne = path.resolve(this.projectRoot, '_one');
     this.dirTwo = path.resolve(this.projectRoot, '_two');
-
+    this.dirOneSubOne = path.resolve(this.projectRoot, '_one/_sub_one');
+    this.dirOneSubTwo = path.resolve(this.projectRoot, '_one/_sub_two');
+    this.dirTwoSubOne = path.resolve(this.projectRoot, '_two/_sub_one');
+    this.dirTwoSubTwo = path.resolve(this.projectRoot, '_two/_sub_two');
     // where root is outside the cwd
     this.outsideProjectRoot = path.resolve(process.cwd(), 'test/outside_root');
     this.dirThree = path.resolve(this.outsideProjectRoot, 'three');

--- a/test/tests.js
+++ b/test/tests.js
@@ -35,6 +35,10 @@ var run = function (setup) {
     var filesystemRoot = _this.filesystemRoot;
     var dirOne = _this.dirOne;
     var dirTwo = _this.dirTwo;
+    var dirOneSubOne = _this.dirOneSubOne;
+    var dirOneSubTwo = _this.dirOneSubTwo;
+    var dirTwoSubOne = _this.dirTwoSubOne;
+    var dirTwoSubTwo = _this.dirTwoSubTwo;
     var dirThree = _this.dirThree;
     var platform = _this.platform || os.platform();
     var cleanWebpackPlugin;
@@ -164,6 +168,43 @@ var run = function (setup) {
       result = cleanWebpackPlugin.apply();
       expect(result[0].output).to.equal('removed');
     });
+
+    describe('exclude', function () {
+      it('one', function() {
+        createDir(dirOneSubOne);
+        cleanWebpackPlugin = new CleanWebpackPlugin(['_one'], { root: projectRoot, exclude: [ '_sub_one' ] });
+        result = cleanWebpackPlugin.apply();
+        expect(result[0].output).to.equal('removed with exclusions (1)');
+      });
+
+      it('multiple files', function() {
+        createDir(dirOneSubTwo);
+        cleanWebpackPlugin = new CleanWebpackPlugin(['_one'], { root: projectRoot, exclude: [ '_sub_one', '_sub_two' ] });
+        result = cleanWebpackPlugin.apply();
+        expect(result[0].output).to.equal('removed with exclusions (2)');
+      });
+
+      it('ignore non-existing', function() {
+        cleanWebpackPlugin = new CleanWebpackPlugin(['_one'], { root: projectRoot, exclude: [ '_sub_three' ] });
+        result = cleanWebpackPlugin.apply();
+        expect(result[0].output).to.equal('removed');
+      });
+
+      it('from multiple directories', function() {
+        createDir(dirOne);
+        createDir(dirTwo);
+        createDir(dirOneSubOne);
+        createDir(dirOneSubTwo);
+        createDir(dirTwoSubOne);
+        createDir(dirTwoSubTwo);
+        cleanWebpackPlugin = new CleanWebpackPlugin(['_one', '_two'], { root: projectRoot, exclude: [ '_sub_one' ] });
+        result = cleanWebpackPlugin.apply();
+        expect(result[0].output).to.equal('removed with exclusions (1)');
+        expect(result[1].output).to.equal('removed with exclusions (1)');
+      });
+    });
+
+
 
     if (platform === 'win32') {
       describe('windows only tests', function () {

--- a/test/windows_spec.js
+++ b/test/windows_spec.js
@@ -29,6 +29,10 @@ describe('windows emulation', function () {
   this.filesystemRoot = convertToWin32Path(path.resolve(('/')));
   this.dirOne = path.win32.resolve(this.projectRoot + path.win32.sep + '_one');
   this.dirTwo = path.win32.resolve(this.projectRoot + path.win32.sep + '_two');
+  this.dirOneSubOne = path.win32.resolve(this.projectRoot + path.win32.sep + '_one/_sub_one');
+  this.dirOneSubTwo = path.win32.resolve(this.projectRoot + path.win32.sep + '_one/_sub_two');
+  this.dirTwoSubOne = path.win32.resolve(this.projectRoot + path.win32.sep + '_two/_sub_one');
+  this.dirTwoSubTwo = path.win32.resolve(this.projectRoot + path.win32.sep + '_two/_sub_two');
   this.dirThree = path.win32.resolve(this.outsideProjectRoot + path.win32.sep + '_three');
   this.CleanWebpackPlugin = CleanWebpackPlugin;
   this.platform = 'win32';
@@ -59,7 +63,14 @@ describe('windows emulation', function () {
         return true;
       },
       'fs.statSync': function () {
-        return true;
+        return {
+          isDirectory: function() {
+            return true;
+          }
+        }
+      },
+      'fs.readdirSync': function() {
+        return ['_sub_one', '_sub_two'];
       }
     });
   });


### PR DESCRIPTION
It is possible now not to remove recursively whole directory to clean, but to remove all it's contents with exclusion of specified paths. Useful when `build` directory is shared by multiple webpack configs and some resources should be ignored by the clean-up phase.
* When there are multiple directories to clean and exclusions are defined, exclusions will be applied to every directory.
* Tested only for immediate children (not sure it's going to work when paths like `dir/subdir` will be provided to the exclusion).
* Tested in action on OS X, not sure if works on Windows, even though the tests are passing...
* When no files to exclude are found, whole build directory will be removed (it won't be left empty).