### PR TITLE
allow excluding `.` i.e. only remove dir contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,6 +146,9 @@ Plugin.prototype.apply = function () {
                 return fullPath;
               });
         }
+        if (_this.options.exclude.indexOf('.') >= 0) {
+          excludedChildren.push('.');
+        }
       } catch (e) {
         childrenAfterExcluding = [];
       }


### PR DESCRIPTION
This PR adds the ability to remove only the contents of the directory instead of removing the whole directory itself. I needed this for a webserver that got confused when the document root directory was being removed.