### PR TITLE
Clean directory after recompile: round two

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ module.exports = {
   plugins: [
     new CleanWebpackPlugin(['dist', 'build'], {
       root: '/full/project/path',
-      verbose: true, 
+      verbose: true,
       dry: false,
       exclude: ['shared.js']
     })
@@ -49,6 +49,7 @@ An [array] of string paths to clean
   "exclude": ["files", "to", "ignore"] // Instead of removing whole path recursively,
                                        // remove all path's content with exclusion of provided immediate children.
                                        // Good for not removing shared files from build directories.
+  "watch": false // If true, remove files on recompile. (Default: false)
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -176,9 +176,14 @@ var clean = function () {
 
 Plugin.prototype.apply = function (compiler) {
     var _this = this;
-    compiler.plugin("compile", function (params) {
-        clean.bind(_this)();
-    });
+    if (compiler === undefined) {
+        return clean.call(_this);
+    }
+    else {
+        compiler.plugin("compile", function (params) {
+            clean.call(_this);
+        });
+    }
 };
 
 module.exports = Plugin;

--- a/index.js
+++ b/index.js
@@ -180,9 +180,14 @@ Plugin.prototype.apply = function (compiler) {
         return clean.call(_this);
     }
     else {
-        compiler.plugin("compile", function (params) {
-            clean.call(_this);
-        });
+        if (_this.option.watch) {
+          compiler.plugin("compile", function (params) {
+              clean.call(_this);
+          });
+        }
+        else {
+          return clean.call(_this);
+        }
     }
 };
 


### PR DESCRIPTION
Hi,

This time I've added the watch functionality as an option instead of a default. Use `{watch: true}` to turn on deletion before recompilation.

This fixes issue #31, but not #29 because the origin of that issue wasn't because of my original pull request.
