### PR TITLE
Add watch and cleanOnApply options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ module.exports = {
       root: '/full/project/path',
       verbose: true, 
       dry: false,
-      exclude: ['shared.js']
+      exclude: ['shared.js'],
+      watch: true
     })
   ]
 }
@@ -46,9 +47,11 @@ An [array] of string paths to clean
   "verbose": true, // Write logs to console.
   "dry": false, // Use boolean "true" to test/emulate delete. (will not remove files).
                 // (Default: "false", remove files)
-  "exclude": ["files", "to", "ignore"] // Instead of removing whole path recursively,
-                                       // remove all path's content with exclusion of provided immediate children.
-                                       // Good for not removing shared files from build directories.
+  "exclude": ["files", "to", "ignore"], // Instead of removing whole path recursively,
+                                        // remove all path's content with exclusion of provided immediate children.
+                                        // Good for not removing shared files from build directories.
+  "watch": false, // Remove files before each compilation (Default: "false")
+  "cleanOnApply": true // Run when plugin is added to (applied on) webpack instance (Default: "true")
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -38,6 +38,9 @@ function Plugin(paths, options) {
     options.dry = false;
   }
 
+  options.watch = !!options.watch;
+  options.cleanOnApply = (options.cleanOnApply === undefined ? true : !!options.cleanOnApply);
+
   // determine webpack root
   options.root = options.root || path.dirname(module.parent.filename);
 
@@ -51,7 +54,7 @@ function Plugin(paths, options) {
   this.options = options;
 }
 
-Plugin.prototype.apply = function () {
+var clean = function () {
   var _this = this;
   var results = [];
   var workingDir;
@@ -176,5 +179,20 @@ Plugin.prototype.apply = function () {
 
   return results;
 };
+
+Plugin.prototype.apply = function (compiler) {
+    var _this = this;
+
+    if(this.options.watch) {
+      compiler.plugin("compilation", function (params) {
+        return clean.call(_this);
+      });
+    }
+
+    if(this.options.cleanOnApply) {
+        return clean.call(_this);
+    }
+};
+
 
 module.exports = Plugin;

--- a/test/Compiler.js
+++ b/test/Compiler.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function Compiler(){
+    this.steps = {}; 
+}
+
+Compiler.prototype.plugin = function (step, func){ this.steps[step] = func; };
+Compiler.prototype.runStep = function (step) { return this.steps[step] && this.steps[step](); };
+
+module.exports = Compiler;

--- a/test/tests.js
+++ b/test/tests.js
@@ -5,6 +5,7 @@ var os = require('os');
 var fs = require('fs');
 var path = require('path');
 var expect = require('chai').expect;
+var Compiler = require('./Compiler');
 
 function createDir(directory) {
   try {
@@ -137,6 +138,43 @@ var run = function (setup) {
       expect(result[0].output).to.equal('removed');
     });
 
+    it('watched disabled by default', function () {
+      createDir(dirOne);
+      cleanWebpackPlugin = new CleanWebpackPlugin(dirOne, { root: projectRoot });
+      var compiler = new Compiler;
+      var applyResult = cleanWebpackPlugin.apply(compiler);
+
+      expect(applyResult[0].output).to.equal('removed');
+
+      var compilationResult = compiler.runStep("compilation");
+      expect(compilationResult).to.equal.undefined;
+    });
+
+    it('options = { watch: true }', function () {
+      createDir(dirOne);
+      cleanWebpackPlugin = new CleanWebpackPlugin(dirOne, { root: projectRoot, watch: true});
+      var compiler = new Compiler;
+      var applyResult = cleanWebpackPlugin.apply(compiler);
+
+      expect(applyResult[0].output).to.equal('removed');
+
+      createDir(dirOne);
+      var compilationResult = compiler.runStep("compilation");
+      expect(compilationResult[0].output).to.equal('removed');
+    });
+
+    it('options = { watch: true, cleanOnApply: false }', function () {
+      createDir(dirOne);
+      cleanWebpackPlugin = new CleanWebpackPlugin(dirOne, { root: projectRoot, watch: true, cleanOnApply: false});
+      var compiler = new Compiler;
+      var applyResult = cleanWebpackPlugin.apply(compiler);
+
+      expect(applyResult).to.be.undefined;
+
+      var compilationResult = compiler.runStep("compilation");
+      expect(compilationResult[0].output).to.equal('removed');
+    });
+
     it('context backwards compatibility ', function () {
       createDir(dirOne);
       cleanWebpackPlugin = new CleanWebpackPlugin(dirOne, projectRoot);
@@ -159,6 +197,18 @@ var run = function (setup) {
       result = cleanWebpackPlugin.apply();
 
       expect(result[0].output).to.equal('removed');
+    });
+
+    it('options = { watch: false, cleanOnApply: false }', function () {
+      cleanWebpackPlugin = new CleanWebpackPlugin(dirOne, { root: projectRoot, watch: false, cleanOnApply: false});
+      var compiler = new Compiler;
+      var applyResult = cleanWebpackPlugin.apply(compiler);
+
+      expect(applyResult).to.be.undefined;
+
+      var compilationResult = compiler.runStep("compilation");
+      expect(compilationResult).to.be.undefined;
+      fs.statSync(dirOne);
     });
 
     it('filesystem root', function () {
@@ -203,7 +253,6 @@ var run = function (setup) {
         expect(result[1].output).to.equal('removed with exclusions (1)');
       });
     });
-
 
 
     if (platform === 'win32') {


### PR DESCRIPTION
Has tests, by default is backward compatible. Fixes #29. Alternative to #32.

TODO:
When watching, keep list of files generated in previous compilation, and upon "emit" or "done" remove those, which are not present in current compilation.