### PR TITLE
Allow using regex in `exclude` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ module.exports = {
       root: '/full/project/path',
       verbose: true, 
       dry: false,
-      exclude: ['shared.js']
+      exclude: ['shared.js', /style_.+\.css/]
     })
   ]
 }

--- a/index.js
+++ b/index.js
@@ -133,7 +133,14 @@ CleanWebpackPlugin.prototype.apply = function () {
         if (pathStat.isDirectory()) {
           childrenAfterExcluding = fs.readdirSync(rimrafPath)
               .filter(function (childFile) {
-                var include = _this.options.exclude.indexOf(childFile) < 0;
+                var include = true;
+
+                _this.options.exclude.forEach(function(exclusionRule) {
+                  if (childFile.match(exclusionRule)) {
+                    include = false;
+                  }
+                });
+
                 if (!include) {
                   excludedChildren.push(childFile);
                 }

--- a/index.js
+++ b/index.js
@@ -138,6 +138,7 @@ CleanWebpackPlugin.prototype.apply = function () {
                 _this.options.exclude.forEach(function(exclusionRule) {
                   if (childFile.match(exclusionRule)) {
                     include = false;
+                    return;
                   }
                 });
 


### PR DESCRIPTION
Sometimes you need to exclude a file but you don't know the exact filename.

In my case, I have two webpack compilers: one for JS and one for CSS. Each output file has a hash appended to it for the purpose of cache busting.

```
application_68554c864f233311b88c.js
application_ed9d2efc35d296699f6d.css
```

When running the JS compiler, I don't want to delete the CSS file generated by a different compiler, but I also don't know the exact name of the CSS file since it contains a hash. This is a where a regex comes in handy:

```
  new CleanWebpackPlugin(['public'], {
    verbose: true,
    exclude: [/application_.+\.css/]
  })
```

Edit: fix regex