### PR TITLE
use ^ for rimraf instead of ~ and update all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "test-travis": "istanbul cover _mocha -- -R spec ./test/*_spec.js"
   },
   "dependencies": {
-    "rimraf": "~2.5.1"
+    "rimraf": "^2.6.1"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
-    "coveralls": "^2.11.6",
-    "istanbul": "^0.4.2",
-    "mocha": "^2.4.2",
-    "rewire": "^2.5.1"
+    "chai": "^4.1.1",
+    "coveralls": "^2.13.1",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.5.0",
+    "rewire": "^2.5.2"
   }
 }


### PR DESCRIPTION
Should fix https://github.com/johnagan/clean-webpack-plugin/issues/59 according to https://github.com/johnagan/clean-webpack-plugin/issues/59#issuecomment-322560841.