### PR TITLE
Perform clean just before emiting files to output dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ An [array] of string paths to clean
   // allow the plugin to clean folders outside of the webpack root.
   // Default: false - don't allow clean folder outside of the webpack root
   allowExternal: false
+  
+  // perform clean just before files are emitted to the output dir
+  // Default: false
+  beforeEmit: false
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ CleanWebpackPlugin.prototype.apply = function(compiler) {
       compiler.plugin("compile", function(params) {
         clean.call(_this);
       });
-    } else if (_this.options.beforeEmit) {
+    } else if (_this.options.beforeEmit && !compiler.options.watch) {
       compiler.plugin("emit", function(compilation, callback) {
         clean.call(_this);
 

--- a/index.js
+++ b/index.js
@@ -187,6 +187,12 @@ CleanWebpackPlugin.prototype.apply = function(compiler) {
       compiler.plugin("compile", function(params) {
         clean.call(_this);
       });
+    } else if (_this.options.beforeEmit) {
+      compiler.plugin("emit", function(compilation, callback) {
+        clean.call(_this);
+
+        callback();
+      });
     } else {
       return clean.call(_this);
     }


### PR DESCRIPTION
Currently the files are removed at the beginning of the compiliing process. For production environments that isn't really what you want, because:
- During compilation the assets aren't available
- When compilation fails, assets are done.

So basically you want the old assets to be cleaned just before the new files are emitted to the output dir. 

This PR does exactly that by using the event hook of the compiler named "emit".

The only thing you have to do is setting "beforeEmit" to true in the options.