### PR TITLE
fix: Messages for success are printed on stderr

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,9 +168,9 @@ var clean = function() {
     }
 
     _this.options.verbose &&
-      console.warn('clean-webpack-plugin: ' + rimrafPath + ' has been removed.');
+      console.log('clean-webpack-plugin: ' + rimrafPath + ' has been removed.');
     _this.options.verbose && excludedChildren.length &&
-      console.warn('clean-webpack-plugin: ' + excludedChildren.length + ' file(s) excluded - ' + excludedChildren.join(', '));
+      console.log('clean-webpack-plugin: ' + excludedChildren.length + ' file(s) excluded - ' + excludedChildren.join(', '));
 
     excludedChildren.length ?
       results.push({ path: rimrafPath, output: 'removed with exclusions (' + excludedChildren.length + ')' }) :


### PR DESCRIPTION
In case the clean operation is successful, the messages for success are printed on stderr. This is misconception as all success messages should be printed on stdout.
Many tools check the stderr output and print errors or even break the process in case there's something printed there.
The current PR changes the method used to print success messages - instead of using console.warn, use console.log.
This will allow external tools to use the stderr output as indication that there was a problem. When the only output is on stdout, they can consider the operation as successful.