### PR TITLE
update description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "clean-webpack-plugin",
   "version": "2.0.0",
   "author": "John Agan <johnagan@gmail.com>",
-  "description": "A webpack plugin to remove your build folder(s) before building",
+  "description": "A webpack plugin to remove/clean your build folder(s).",
   "homepage": "https://github.com/johnagan/clean-webpack-plugin",
   "license": "MIT",
   "main": "dist/clean-webpack-plugin.js",


### PR DESCRIPTION
Since this plugin isn't used only for _before building_ anymore, I'd recommend updating the Github description as well. `A webpack plugin to remove/clean your build folder(s)`