### PR TITLE
fix: cleanAfterEveryBuildPatterns negative patterns

### DIFF
--- a/src/clean-webpack-plugin.ts
+++ b/src/clean-webpack-plugin.ts
@@ -249,18 +249,24 @@ class CleanWebpackPlugin {
          */
         this.currentAssets = assets.sort();
 
+        const removePatterns = [];
+
         /**
          * Remove unused webpack assets
          */
         if (this.cleanStaleWebpackAssets === true && staleFiles.length !== 0) {
-            this.removeFiles(staleFiles);
+            removePatterns.push(...staleFiles);
         }
 
         /**
-         * Run cleanAfterEveryBuildPatterns
+         * Remove cleanAfterEveryBuildPatterns
          */
         if (this.cleanAfterEveryBuildPatterns.length !== 0) {
-            this.removeFiles(this.cleanAfterEveryBuildPatterns);
+            removePatterns.push(...this.cleanAfterEveryBuildPatterns);
+        }
+
+        if (removePatterns.length !== 0) {
+            this.removeFiles(removePatterns);
         }
     }
 


### PR DESCRIPTION
Adding negative patterns to `cleanAfterEveryBuildPatterns` was not excluding matching stale webpack assets. This is an issue when using this plugin with something like [copy-webpack-plugin](https://github.com/webpack-contrib/copy-webpack-plugin) that does not persist with webpack's reported assets.

I think we should release an update to npm after merging this.