### PR TITLE
fix: do not clean directory if webpack errors are present during initial build

### DIFF
--- a/src/clean-webpack-plugin.ts
+++ b/src/clean-webpack-plugin.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import { sync as delSync } from 'del';
-import { Compiler, Stats } from 'webpack';
+import { Compiler, Stats, compilation as compilationType } from 'webpack';
+
+type Compilation = compilationType.Compilation;
 
 export interface Options {
     /**
@@ -173,12 +175,18 @@ class CleanWebpackPlugin {
 
         if (this.cleanOnceBeforeBuildPatterns.length !== 0) {
             if (hooks) {
-                hooks.compile.tap('clean-webpack-plugin', () => {
-                    this.handleInitial();
+                hooks.emit.tap('clean-webpack-plugin', (compilation) => {
+                    this.handleInitial(compilation);
                 });
             } else {
-                compiler.plugin('compile', () => {
-                    this.handleInitial();
+                compiler.plugin('emit', (compilation, callback) => {
+                    try {
+                        this.handleInitial(compilation);
+
+                        callback();
+                    } catch (error) {
+                        callback(error);
+                    }
                 });
             }
         }
@@ -201,8 +209,18 @@ class CleanWebpackPlugin {
      *
      * Warning: It is recommended to initially clean your build directory outside of webpack to minimize unexpected behavior.
      */
-    handleInitial() {
+    handleInitial(compilation: Compilation) {
         if (this.initialClean) {
+            return;
+        }
+
+        /**
+         * Do not remove files if there are compilation errors
+         *
+         * Handle logging inside this.handleDone
+         */
+        const stats = compilation.getStats();
+        if (stats.hasErrors()) {
             return;
         }
 


### PR DESCRIPTION
Please hold off on merging this.

Although this is a fix for #133, is it also a breaking change? I think it could be if someone is using a webpack plugin that manually creates files inside webpack's `output.path` after the `compile` hook, although this is not supported by webpack and probably can/should be ignored. Thoughts?