### PR TITLE
replace default export with named export CleanWebpackPlugin

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -14,17 +14,6 @@ const babel = {
         ],
         '@babel/preset-typescript',
     ],
-    overrides: [
-        {
-            test: ['./src/clean-webpack-plugin.ts'],
-            plugins: [
-                [
-                    'babel-plugin-add-module-exports',
-                    { addDefaultProperty: true },
-                ],
-            ],
-        },
-    ],
 };
 
 module.exports = babel;

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,9 +2,6 @@
 
 const eslint = {
     extends: '@chrisblossom/eslint-config',
-    rules: {
-        'import/no-default-export': 'off',
-    },
     overrides: [
         {
             files: ['dev-utils/**/*.js', 'dev-utils/**/.*.js'],

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ By default, this plugin will remove all files inside webpack's `output.path` dir
 ## Usage
 
 ```js
-const CleanWebpackPlugin = require('clean-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 const webpackConfig = {
     plugins: [
@@ -126,7 +126,7 @@ new CleanWebpackPlugin({
 This is a modified version of [WebPack's Plugin documentation](https://webpack.js.org/concepts/plugins/) that includes the Clean Plugin.
 
 ```js
-const CleanWebpackPlugin = require('clean-webpack-plugin'); // installed via npm
+const { CleanWebpackPlugin } = require('clean-webpack-plugin'); // installed via npm
 const HtmlWebpackPlugin = require('html-webpack-plugin'); // installed via npm
 const webpack = require('webpack'); // to access built-in plugins
 const path = require('path');

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@types/node": "^12.0.2",
     "@types/read-pkg-up": "^3.0.1",
     "babel-jest": "^24.8.0",
-    "babel-plugin-add-module-exports": "^1.0.2",
     "codecov": "^3.5.0",
     "cross-env": "^5.2.0",
     "del-cli": "^1.1.0",

--- a/src/clean-webpack-plugin.test.ts
+++ b/src/clean-webpack-plugin.test.ts
@@ -46,7 +46,8 @@ function webpack(options: Configuration = {}) {
 }
 
 const CleanWebpackPlugin: any = function CleanWebpackPlugin(...args: any) {
-    const CleanWebpackPluginActual = require('./clean-webpack-plugin');
+    const CleanWebpackPluginActual = require('./clean-webpack-plugin')
+        .CleanWebpackPlugin;
     const cleanWebpackPlugin = new CleanWebpackPluginActual(...args);
     return cleanWebpackPlugin;
 };

--- a/src/clean-webpack-plugin.ts
+++ b/src/clean-webpack-plugin.ts
@@ -347,4 +347,4 @@ class CleanWebpackPlugin {
     }
 }
 
-export default CleanWebpackPlugin;
+export { CleanWebpackPlugin };


### PR DESCRIPTION
Please hold off on merging this as it is a breaking change.

> https://github.com/johnagan/clean-webpack-plugin/issues/114#issuecomment-473204185
> Oh, this lib is written in TS, I thought it just had a d.ts file. Then I would not change anything and just document the fact that consumers needs to add .default if their IDE/typechecker is yelling at them. The interop with CJS will always be a bit painful/ugly I think.
> 
> Jest will move to ES module exports in the next major and ditch export =.
> 
> One thing you can do is have a named export in addition to the default one, so people can do const CleanPlugin = require('clean-webpack-plugin').plugin; or something. Not much of a difference, but looks better than default, at least to my eyes

This PR removes the default export and replaces it with a named export `CleanWebpackPlugin`. It will work better with editors, improved es module/common js interoperability, and removes the _(barely maintained)_ plugin [`babel-plugin-add-module-exports`](https://github.com/59naga/babel-plugin-add-module-exports/issues).

To upgrade users will need to update how they require/import the plugin.

```js
// es modules
import { CleanWebpackPlugin } from 'clean-webpack-plugin';

// common js
const { CleanWebpackPlugin } = require('clean-webpack-plugin');
```

This will also fix https://github.com/johnagan/clean-webpack-plugin/issues/114.

I personally think this is a good/future proof change. Thoughts?