### PR TITLE
3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clean-webpack-plugin",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "author": "John Agan <johnagan@gmail.com>",
   "description": "A webpack plugin to remove/clean your build folder(s).",
   "homepage": "https://github.com/johnagan/clean-webpack-plugin",


### PR DESCRIPTION
This is an alternate to #145. Only merge one, close other.

Changelog:

- Removed Node 6 support
- Removed webpack 2 support
- `cleanOnceBeforeBuildPatterns` use `emit` hook instead of `compile`
- Do not clean files if webpack errors are present during initial build
- Replaced default export with named export `CleanWebpackPlugin`
```js
// es modules
import { CleanWebpackPlugin } from 'clean-webpack-plugin';

// common js
const { CleanWebpackPlugin } = require('clean-webpack-plugin');
```
