### PR TITLE
use np to handle package releases

### DIFF
--- a/.np-config.js
+++ b/.np-config.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+    yarn: false,
+};

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "typescript": "tsc",
     "git-pre-commit": "lint-staged",
     "git-pre-push": "npm run lint && npm run typescript && npm run test.all",
-    "prepublishOnly": "npm run build && npm run lint && npm run typescript && npm run test.all"
+    "prepublishOnly": "npm run build && npm run lint && npm run typescript && npm run test.all",
+    "release": "np"
   },
   "peerDependencies": {
     "webpack": "*"
@@ -67,6 +68,7 @@
     "jest": "^24.8.0",
     "lint-staged": "^8.1.7",
     "listr": "^0.14.3",
+    "np": "^5.0.2",
     "prettier": "^1.17.1",
     "read-pkg-up": "^6.0.0",
     "semver": "^6.0.0",


### PR DESCRIPTION
This is an alternate to https://github.com/johnagan/clean-webpack-plugin/pull/144. Only merge one, close other.

This PR adds the package [np](https://github.com/sindresorhus/np) to handle package releases. It will automate most everything you need to do when releasing an updated version. [See the readme](https://github.com/sindresorhus/np#np--) for a more detailed explanation on why.

Use the script `npm run release` instead of `npm publish` and follow the prompts.

Note: you might need to update your version of npm using `npm install -g npm@latest`

Changelog:

- Removed Node 6 support
- Removed webpack 2 support
- `cleanOnceBeforeBuildPatterns` use `emit` hook instead of `compile`
- Do not clean files if webpack errors are present during initial build
- Replaced default export with named export `CleanWebpackPlugin`
```js
// es modules
import { CleanWebpackPlugin } from 'clean-webpack-plugin';

// common js
const { CleanWebpackPlugin } = require('clean-webpack-plugin');
```
