### PR TITLE
use afterCompile hook for cleanOnceBeforeBuildPatterns

### DIFF
--- a/src/clean-webpack-plugin.ts
+++ b/src/clean-webpack-plugin.ts
@@ -185,11 +185,14 @@ class CleanWebpackPlugin {
 
         if (this.cleanOnceBeforeBuildPatterns.length !== 0) {
             if (hooks) {
-                hooks.emit.tap('clean-webpack-plugin', (compilation) => {
-                    this.handleInitial(compilation);
-                });
+                hooks.afterCompile.tap(
+                    'clean-webpack-plugin',
+                    (compilation) => {
+                        this.handleInitial(compilation);
+                    },
+                );
             } else {
-                compiler.plugin('emit', (compilation, callback) => {
+                compiler.plugin('after-compile', (compilation, callback) => {
                     try {
                         this.handleInitial(compilation);
 


### PR DESCRIPTION
Why: works better with other plugins so plugin order shouldn't matter.

Since this happens before `emit`, it is not a breaking change.

Fixes #150 and maybe #146.