### PR TITLE
perf: skip heavy resource webpack stats

### DIFF
--- a/src/clean-webpack-plugin.ts
+++ b/src/clean-webpack-plugin.ts
@@ -257,7 +257,13 @@ class CleanWebpackPlugin {
         /**
          * Fetch Webpack's output asset files
          */
-        const assets = stats.toJson().assets || [];
+        const assets =
+            stats.toJson(
+                {
+                    assets: true,
+                },
+                true,
+            ).assets || [];
         const assetList = assets.map((asset: { name: string }) => {
             return asset.name;
         });


### PR DESCRIPTION
## Summary

Since we only need assets from webpack stats.toJson(), we can pass 'forToString` option in https://github.com/webpack/webpack/blob/42407cb5616aff940935cb58a4fda8429140c122/lib/Stats.js#L104 to skip heavy resource webpack stats

This shall reduce memory usage and improve performance

## Test Plan

<img width="528" alt="1" src="https://user-images.githubusercontent.com/17883920/66739374-bcb71480-ee9a-11e9-952f-4556a7811374.PNG">
