### PR TITLE
feat: allow to preserve previous builds for `maxAge` seconds

### DIFF
--- a/src/clean-webpack-plugin.test.ts
+++ b/src/clean-webpack-plugin.test.ts
@@ -1327,9 +1327,9 @@ describe('webpack >= 4 only', () => {
 
             const cleanWebpackPlugin = new CleanWebpackPlugin();
 
-            // @ts-ignore
             const compiler = webpack({
                 // internal test option to remove mode
+                // @ts-ignore
                 mode: null,
                 plugins: [cleanWebpackPlugin],
             });

--- a/src/clean-webpack-plugin.test.ts
+++ b/src/clean-webpack-plugin.test.ts
@@ -1133,6 +1133,43 @@ describe('verbose option', () => {
     });
 });
 
+describe('preserve option', () => {
+    test('does not remove files with `maxAge` set', async () => {
+        createSrcBundle(2);
+
+        const compiler = webpack({
+            entry: entryFileFull,
+            output: {
+                path: outputPathFull,
+                filename: 'bundle.js',
+                chunkFilename: '[name].bundle.js',
+            },
+            plugins: [new CleanWebpackPlugin({ preserve: { maxAge: 10000 } })],
+        });
+
+        await compiler.run();
+
+        const compiler1 = webpack({
+            entry: entryFileFull,
+            output: {
+                path: outputPathFull,
+                filename: 'bundle.js',
+                chunkFilename: '[name].bundle.js',
+            },
+            plugins: [new CleanWebpackPlugin({ preserve: { maxAge: 10000 } })],
+        });
+
+        createSrcBundle(1);
+
+        await compiler1.run();
+
+        expect(sandbox.getFileListSync(outputPathFull)).toEqual([
+            '1.bundle.js',
+            'bundle.js',
+        ]);
+    });
+});
+
 describe('webpack errors', () => {
     test('does nothing when webpack errors are present on initial build', async () => {
         createSrcBundle(2);

--- a/src/clean-webpack-plugin.ts
+++ b/src/clean-webpack-plugin.ts
@@ -141,6 +141,7 @@ class CleanWebpackPlugin {
         filename: string;
         path: string;
     };
+
     private currentAssets: string[];
     private initialClean: boolean;
     private outputPath: string;


### PR DESCRIPTION
Fixes #176, #3
@johnagan, @chrisblossom, I can think of three ways (there could be more) not preserving some of the recent builds might backfire:
  - someone's using a website during deployment and requests split chunks previously not loaded that are no longer there
  - if a dev decides to cache `index.html` with a service like Cloudflare, and a split chunk was not requested before and therefore not cached, and is now requested.
  - if there was not enough time to load everything, service worker would try to load the rest during the next visit?

It's still a draft because I don't know if you're interested and if I'm moving in the right direction. So far I save the list of assets from previous builds in a file, `filename` and `path` are configurable. `preserve` option is only handled on initial builds, should it work during `watch` rebuilds as well? Potential improvements:
  - allow `preserve` to be a number (`maxAge`) - could be confusing if in the future we decide to add `nPreviousBuilds` additional option alongside `maxAge`
  - remove duplicates from `assetList` with a `Set` - unless it does not improve performance of `del`